### PR TITLE
Fix add todo bug

### DIFF
--- a/template/frontend/components/todo-list.vue
+++ b/template/frontend/components/todo-list.vue
@@ -45,7 +45,7 @@ export default {
     async add () {
       this.adding = true
       const response = await api.add_todo(this.newtask)
-      this.items.push(response.todo)
+      this.items.push(response)
       this.newtask = ''
       this.adding = false
     }


### PR DESCRIPTION
API response is just a JSON with the following format:

```
{
    'id': 4,
    'description': "do something",
    'done': false
}
```

So, `response.todo` returns `undefined`